### PR TITLE
project: rename from sxplayer to nope.media

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -54,7 +54,7 @@ jobs:
 
         make install -j$(($(nproc)+1))
 
-    - name: Build sxplayer lib for Android
+    - name: Build nope.media for Android
       run: |
         PKG_CONFIG_LIBDIR=$HOME/ffmpeg-install-${{ matrix.arch }}/lib/pkgconfig/ \
         meson setup --cross-file .github/meson-android-${{ matrix.arch }}.ini builddir

--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -68,7 +68,7 @@ jobs:
 
         make install -j $(sysctl -n hw.ncpu)
 
-    - name: Build sxplayer lib for ios
+    - name: Build nope.media for ios
       run: |
         PKG_CONFIG_LIBDIR=$HOME/ffmpeg-install-${{ matrix.ffmpeg_version }}/lib/pkgconfig \
         LDFLAGS="$LDFLAGS -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Project is forked and renamed to nope.media
+
 ## [9.14.0] - 2023-03-09
 ### Added
 - Support for log messages of any length
@@ -53,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.9.0] - 2021-06-10
 ### Added
 - Automatic software pixel format selection
-- New datap and linesizep fields to sxplayer frame
+- New datap and linesizep fields to frame
 - NV12, YUV420P, YUV422P, YUV444P support
 - P010LE, YUV420PLE, YUV422P10LE, YUV444P10LE support
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# sxplayer
+# nope.media
 
-![tests Linux](https://github.com/gopro/sxplayer/workflows/tests%20Linux/badge.svg)
-![tests Mac](https://github.com/gopro/sxplayer/workflows/tests%20Mac/badge.svg)
-![tests Windows](https://github.com/gopro/sxplayer/workflows/tests%20Windows/badge.svg)
-![build Android 🤖](https://github.com/gopro/sxplayer/workflows/build%20Android%20🤖/badge.svg)
-![build iOS 🍏](https://github.com/gopro/sxplayer/workflows/build%20iOS%20🍏/badge.svg)
+![tests Linux](https://github.com/nope-project/nope.media/workflows/tests%20Linux/badge.svg)
+![tests Mac](https://github.com/nope-project/nope.media/workflows/tests%20Mac/badge.svg)
+![tests Windows](https://github.com/nope-project/nope.media/workflows/tests%20Windows/badge.svg)
+![build Android 🤖](https://github.com/nope-project/nope.media/workflows/build%20Android%20🤖/badge.svg)
+![build iOS 🍏](https://github.com/nope-project/nope.media/workflows/build%20iOS%20🍏/badge.svg)
 
 ## Introduction
 
-`sxplayer` stands for Stupeflix Player, a video frames fetching library.
+`nope.media` is a video player library for fetching frames at exact times.
 
 It can handle only one stream at a time, generally video. If audio is
 requested, the frame returned will be an instant video frame containing both
@@ -34,19 +34,19 @@ documentation][meson-doc] for more information.
 
 ## API Usage
 
-For API usage, refers to `sxplayer.h`.
+For API usage, refers to `nopemd.h`.
 
 
 ## Development
 
 ### Running tests
 
-Assuming sxplayer is built within a `builddir` directory (`meson builddir &&
-meson compile -C builddir`), the test can be run with meson using a command
+Assuming `nope.media` is built within a `builddir` directory (`meson builddir
+&& meson compile -C builddir`), the test can be run with meson using a command
 such as `meson test -C builddir -v`.
 
 The testing program itself (`test-prog`) can be found in the build directory,
-along a sample player tool named `sxplayer` (if its dependencies were met at
+along a sample player tool named `nope-media` (if its dependencies were met at
 build time), which can be used for other manual testing purposes.
 
 ### Infrastructure overview
@@ -59,15 +59,15 @@ build time), which can be used for other manual testing purposes.
               .                             .   .------------.               .-----------------------------------------------------.
               .                             .   | api.c      |               | control                                             |
               .                             .   +------------+               +-----------------------------------------------------+
-           ===.===  sxplayer_create() ======.==>|            |===  init  ===>|                                                     |
+           ===.===  nmd_create()      ======.==>|            |===  init  ===>|                                                     |
               .                             .   |            |---  start  -->|                    MANAGE THREADS                   |
-           ===.===  sxplayer_get_*frame() ==.==>|            |---  seek  --->|              _________/  |  \_______                |
+           ===.===  nmd_get_*frame()      ==.==>|            |---  seek  --->|              _________/  |  \_______                |
   USER        .                             .   |            |---  stop  --->|             /            |          \               |
-           ---.---  sxplayer_start() -------.-->|            |===  free  ===>|            /             |           \              |
-           ---.---  sxplayer_seek()  -------.-->|            |               |           v              v            v             |
-           ---.---  sxplayer_seek()  -------.-->|            |               |      .----------.  .----------.  .----------.       |
+           ---.---  nmd_start()      -------.-->|            |===  free  ===>|            /             |           \              |
+           ---.---  nmd_seek()       -------.-->|            |               |           v              v            v             |
+           ---.---  nmd_seek()       -------.-->|            |               |      .----------.  .----------.  .----------.       |
               .                             .   |            |               |      | demuxer  |  | decoder  |  | filterer |       |
-           ===.===  sxplayer_free()  =======.==>|            |               |      +----------+  +----------+  +----------+       |
+           ===.===  nmd_free()       =======.==>|            |               |      +----------+  +----------+  +----------+       |
               .                             .   |            |               |      | init     |  | init     |  | init     |       |
               .                             .   `------------'               |      +----------+  +----------+  +----------+       |
               .                             .                                |      |          |  |          |  |          |       |

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'sxplayer',
+  'nope.media',
   'c',
   default_options: ['c_std=c99'],
   license: 'LGPL-2.1',
@@ -89,17 +89,17 @@ lib_src = files(
 
 lib_c_args = []
 if get_option('default_library') == 'shared'
-  lib_c_args += '-DBUILD_SXPLAYER_SHARED_LIB'
+  lib_c_args += '-DBUILD_NOPE_MEDIA_SHARED_LIB'
 else
-  lib_c_args += '-DUSE_SXPLAYER_STATIC_LIB'
+  lib_c_args += '-DUSE_NOPE_MEDIA_STATIC_LIB'
 endif
 
 if host_system == 'darwin'
   lib_src += files('src/decoder_vt.c')
 endif
 
-libsxplayer = library(
-  'sxplayer',
+libnopemd = library(
+  'nopemd',
   lib_src,
   dependencies: lib_deps,
   install: true,
@@ -110,25 +110,25 @@ libsxplayer = library(
 )
 
 lib_header = configure_file(
-  input: files('src/sxplayer.h.in'),
-  output: 'sxplayer.h',
+  input: files('src/nopemd.h.in'),
+  output: 'nopemd.h',
   configuration: conf_data
 )
 install_headers(lib_header)
 if get_option('cpp-header')
-  install_headers(files('src/sxplayer.hpp'))
+  install_headers(files('src/nopemd.hpp'))
 endif
 
 pkg = import('pkgconfig')
 pkg_extra_cflags = []
 if get_option('default_library') == 'static'
-  pkg_extra_cflags += '-DUSE_SXPLAYER_STATIC_LIB'
+  pkg_extra_cflags += '-DUSE_NOPE_MEDIA_STATIC_LIB'
 endif
 
 pkg.generate(
-  libsxplayer,
-  name: 'libsxplayer',  # not specifying the name would fallback on "sxplayer.pc" instead of "libsxplayer.pc"
-  description: 'Stupeflix Player library',
+  libnopemd,
+  name: 'libnopemd',  # not specifying the name would fallback on "nopemd.pc" instead of "libnopemd.pc"
+  description: 'nope.media library',
   extra_cflags: pkg_extra_cflags,
 )
 
@@ -146,10 +146,10 @@ foreach dep : player_deps
 endforeach
 if player_deps_found
   player = executable(
-    'sxplayer',
-    files('src/sxplayer.c'),
+    'nope-media',
+    files('src/nope-media.c'),
     dependencies: player_deps,
-    link_with: libsxplayer,
+    link_with: libnopemd,
     install: true,
     install_rpath: install_rpath,
   )
@@ -184,7 +184,7 @@ if get_option('tests')
       'test_' + exe_name,
       files('tests/test_@0@.c'.format(exe_name)),
       dependencies: lib_deps,
-      link_with: libsxplayer,
+      link_with: libnopemd,
       install: false,
       # pkg-config extra cflags don't apply to local executables, so we have to
       # transfer them manually. Alternatively, we could create a virtual

--- a/src/async.h
+++ b/src/async.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -23,31 +23,31 @@
 
 #include <stdint.h>
 
-#include "sxplayer.h"
+#include "nopemd.h"
 #include "opts.h"
 #include "msg.h"
 
-const char *sxpi_async_get_msg_type_string(enum msg_type type);
+const char *nmdi_async_get_msg_type_string(enum msg_type type);
 
-void sxpi_msg_free_data(void *arg);
+void nmdi_msg_free_data(void *arg);
 
-struct async_context *sxpi_async_alloc_context(void);
+struct async_context *nmdi_async_alloc_context(void);
 
-int sxpi_async_init(struct async_context *actx, void *log_ctx,
-                    const char *filename, const struct sxplayer_opts *o);
+int nmdi_async_init(struct async_context *actx, void *log_ctx,
+                    const char *filename, const struct nmdi_opts *o);
 
-int sxpi_async_start(struct async_context *actx);
+int nmdi_async_start(struct async_context *actx);
 
-int sxpi_async_fetch_info(struct async_context *actx, struct sxplayer_info *info);
+int nmdi_async_fetch_info(struct async_context *actx, struct nmd_info *info);
 
-int sxpi_async_seek(struct async_context *actx, int64_t ts);
+int nmdi_async_seek(struct async_context *actx, int64_t ts);
 
-int sxpi_async_pop_frame(struct async_context *actx, AVFrame **framep);
+int nmdi_async_pop_frame(struct async_context *actx, AVFrame **framep);
 
-int sxpi_async_stop(struct async_context *actx);
+int nmdi_async_stop(struct async_context *actx);
 
-int sxpi_sxpi_async_started(struct async_context *actx);
+int nmdi_nmdi_async_started(struct async_context *actx);
 
-void sxpi_async_free(struct async_context **actxp);
+void nmdi_async_free(struct async_context **actxp);
 
 #endif /* ASYNC_H */

--- a/src/decoder_ffmpeg.c
+++ b/src/decoder_ffmpeg.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -141,7 +141,7 @@ static int init_vaapi(struct decoder_ctx *ctx)
 }
 #endif
 
-static int ffdec_init_sw(struct decoder_ctx *ctx, const struct sxplayer_opts *opts)
+static int ffdec_init_sw(struct decoder_ctx *ctx, const struct nmdi_opts *opts)
 {
     AVCodecContext *avctx = ctx->avctx;
     avctx->thread_count = 0;
@@ -150,7 +150,7 @@ static int ffdec_init_sw(struct decoder_ctx *ctx, const struct sxplayer_opts *op
     return avcodec_open2(avctx, codec, NULL);
 }
 
-static int ffdec_init_hw(struct decoder_ctx *ctx, const struct sxplayer_opts *opts)
+static int ffdec_init_hw(struct decoder_ctx *ctx, const struct nmdi_opts *opts)
 {
 #if HAVE_MEDIACODEC_HWACCEL
     return init_mediacodec(ctx);
@@ -217,7 +217,7 @@ static int ffdec_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt)
                         next_pts += dec_frame->nb_samples;
                 }
 
-                ret = sxpi_decoding_queue_frame(ctx->decoding_ctx, dec_frame);
+                ret = nmdi_decoding_queue_frame(ctx->decoding_ctx, dec_frame);
                 if (ret < 0) {
                     TRACE(ctx, "Could not queue frame: %s", av_err2str(ret));
                     av_frame_free(&dec_frame);
@@ -233,7 +233,7 @@ static int ffdec_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt)
         ret = 0;
 
     if (flush)
-        ret = sxpi_decoding_queue_frame(ctx->decoding_ctx, NULL);
+        ret = nmdi_decoding_queue_frame(ctx->decoding_ctx, NULL);
 
     return ret;
 }
@@ -244,14 +244,14 @@ static void ffdec_flush(struct decoder_ctx *ctx)
     avcodec_flush_buffers(avctx);
 }
 
-const struct decoder sxpi_decoder_ffmpeg_sw = {
+const struct decoder nmdi_decoder_ffmpeg_sw = {
     .name        = "ffmpeg_sw",
     .init        = ffdec_init_sw,
     .push_packet = ffdec_push_packet,
     .flush       = ffdec_flush,
 };
 
-const struct decoder sxpi_decoder_ffmpeg_hw = {
+const struct decoder nmdi_decoder_ffmpeg_hw = {
     .name        = "ffmpeg_hw",
     .init        = ffdec_init_hw,
     .push_packet = ffdec_push_packet,

--- a/src/decoder_vt.c
+++ b/src/decoder_vt.c
@@ -1,21 +1,21 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  * Copyright (c) 2012 Sebastien Zwickert
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -223,7 +223,7 @@ static int push_async_frame(struct decoder_ctx *dec_ctx,
         return AVERROR(ENOMEM);
     }
     TRACE(dec_ctx, "push frame pts=%"PRId64, frame->pts);
-    ret = sxpi_decoding_queue_frame(dec_ctx->decoding_ctx, frame);
+    ret = nmdi_decoding_queue_frame(dec_ctx->decoding_ctx, frame);
     if (ret < 0)
         av_frame_free(&frame);
     return ret;
@@ -418,7 +418,7 @@ static enum AVPixelFormat select_pix_fmt(const enum AVPixelFormat *pix_fmts,
     return best;
 }
 
-static int vtdec_init(struct decoder_ctx *dec_ctx, const struct sxplayer_opts *opts)
+static int vtdec_init(struct decoder_ctx *dec_ctx, const struct nmdi_opts *opts)
 {
     int ret;
     AVCodecContext *avctx = dec_ctx->avctx;
@@ -477,7 +477,7 @@ static int vtdec_init(struct decoder_ctx *dec_ctx, const struct sxplayer_opts *o
 
     vt->out_w = avctx->width;
     vt->out_h = avctx->height;
-    sxpi_update_dimensions(&vt->out_w, &vt->out_h, opts->max_pixels);
+    nmdi_update_dimensions(&vt->out_w, &vt->out_h, opts->max_pixels);
     TRACE(dec_ctx, "dimensions: %dx%d -> %dx%d (nb pixels: %d -> %d for a max of %d)\n",
           avctx->width, avctx->height, vt->out_w, vt->out_h,
           avctx->width * avctx->height, vt->out_w * vt->out_h,
@@ -684,7 +684,7 @@ static void vtdec_flush(struct decoder_ctx *dec_ctx)
 
     TRACE(dec_ctx, "decompression session finished delaying frames");
     send_queued_frames(dec_ctx);
-    sxpi_decoding_queue_frame(dec_ctx->decoding_ctx, NULL);
+    nmdi_decoding_queue_frame(dec_ctx->decoding_ctx, NULL);
     TRACE(dec_ctx, "queue cleared, flush ends");
 }
 
@@ -711,7 +711,7 @@ static void vtdec_uninit(struct decoder_ctx *dec_ctx)
     deccounter_update(-1);
 }
 
-const struct decoder sxpi_decoder_vt = {
+const struct decoder nmdi_decoder_vt = {
     .name             = "videotoolbox",
     .init             = vtdec_init,
     .push_packet      = vtdec_push_packet,

--- a/src/decoders.c
+++ b/src/decoders.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -22,7 +22,7 @@
 #include "internal.h"
 #include "log.h"
 
-struct decoder_ctx *sxpi_decoder_alloc(void)
+struct decoder_ctx *nmdi_decoder_alloc(void)
 {
     struct decoder_ctx *ctx = av_mallocz(sizeof(*ctx));
     if (!ctx)
@@ -35,12 +35,12 @@ struct decoder_ctx *sxpi_decoder_alloc(void)
     return ctx;
 }
 
-int sxpi_decoder_init(void *log_ctx,
-                 struct decoder_ctx *ctx,
-                 const struct decoder *dec,
-                 const AVStream *stream,
-                 struct decoding_ctx *decoding_ctx,
-                 const struct sxplayer_opts *opts)
+int nmdi_decoder_init(void *log_ctx,
+                      struct decoder_ctx *ctx,
+                      const struct decoder *dec,
+                      const AVStream *stream,
+                      struct decoding_ctx *decoding_ctx,
+                      const struct nmdi_opts *opts)
 {
     int ret;
 
@@ -56,7 +56,7 @@ int sxpi_decoder_init(void *log_ctx,
     }
 
     // We need to copy the stream information because the stream (and its codec
-    // context) can be destroyed any time after the sxpi_decoder_init() returns
+    // context) can be destroyed any time after the nmdi_decoder_init() returns
     avcodec_parameters_to_context(ctx->avctx, stream->codecpar);
 
     // The MediaCodec decoder needs pkt_timebase in order to rescale the
@@ -77,18 +77,18 @@ int sxpi_decoder_init(void *log_ctx,
     return 0;
 }
 
-int sxpi_decoder_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt)
+int nmdi_decoder_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt)
 {
     return ctx->dec->push_packet(ctx, pkt);
 }
 
-void sxpi_decoder_flush(struct decoder_ctx *ctx)
+void nmdi_decoder_flush(struct decoder_ctx *ctx)
 {
     TRACE(ctx, "flush");
     ctx->dec->flush(ctx);
 }
 
-void sxpi_decoder_free(struct decoder_ctx **ctxp)
+void nmdi_decoder_free(struct decoder_ctx **ctxp)
 {
     struct decoder_ctx *ctx = *ctxp;
     if (!ctx)

--- a/src/decoders.h
+++ b/src/decoders.h
@@ -1,25 +1,25 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef SXPLAYER_DECODERS_H
-#define SXPLAYER_DECODERS_H
+#ifndef NOPE_MEDIA_DECODERS_H
+#define NOPE_MEDIA_DECODERS_H
 
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -39,22 +39,22 @@ struct decoder_ctx {
 
 struct decoder {
     const char *name;
-    int (*init)(struct decoder_ctx *ctx, const struct sxplayer_opts *opts);
+    int (*init)(struct decoder_ctx *ctx, const struct nmdi_opts *opts);
     void (*uninit)(struct decoder_ctx *ctx);
     int (*push_packet)(struct decoder_ctx *ctx, const AVPacket *pkt);
     void (*flush)(struct decoder_ctx *ctx);
     int priv_data_size;
 };
 
-struct decoder_ctx *sxpi_decoder_alloc(void);
-int sxpi_decoder_init(void *log_ctx,
+struct decoder_ctx *nmdi_decoder_alloc(void);
+int nmdi_decoder_init(void *log_ctx,
                       struct decoder_ctx *ctx,
                       const struct decoder *dec,
                       const AVStream *stream,
                       struct decoding_ctx *decoding_ctx,
-                      const struct sxplayer_opts *opts);
-int sxpi_decoder_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt);
-void sxpi_decoder_flush(struct decoder_ctx *ctx);
-void sxpi_decoder_free(struct decoder_ctx **ctxp);
+                      const struct nmdi_opts *opts);
+int nmdi_decoder_push_packet(struct decoder_ctx *ctx, const AVPacket *pkt);
+void nmdi_decoder_flush(struct decoder_ctx *ctx);
+void nmdi_decoder_free(struct decoder_ctx **ctxp);
 
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -1,25 +1,25 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef SXPLAYER_INTERNAL_H
-#define SXPLAYER_INTERNAL_H
+#ifndef NOPE_MEDIA_INTERNAL_H
+#define NOPE_MEDIA_INTERNAL_H
 
 #include <stdio.h>
 #include <libavcodec/version.h>
@@ -28,7 +28,7 @@
 #include <libavutil/samplefmt.h>
 #include <libavutil/timestamp.h>
 
-#include "sxplayer.h"
+#include "nopemd.h"
 
 #ifdef __ANDROID__
 #define HAVE_MEDIACODEC_HWACCEL 1
@@ -40,15 +40,15 @@
 #define HAVE_VAAPI_HWACCEL 0
 #endif
 
-enum AVPixelFormat sxpi_pix_fmts_sx2ff(enum sxplayer_pixel_format pix_fmt);
-enum sxplayer_pixel_format sxpi_pix_fmts_ff2sx(enum AVPixelFormat pix_fmt);
-enum sxplayer_pixel_format sxpi_smp_fmts_ff2sx(enum AVSampleFormat smp_fmt);
-void sxpi_set_thread_name(const char *name);
-void sxpi_update_dimensions(int *width, int *height, int max_pixels);
+enum AVPixelFormat nmdi_pix_fmts_nmd2ff(enum nmd_pixel_format pix_fmt);
+enum nmd_pixel_format nmdi_pix_fmts_ff2nmd(enum AVPixelFormat pix_fmt);
+enum nmd_pixel_format nmdi_smp_fmts_ff2nmd(enum AVSampleFormat smp_fmt);
+void nmdi_set_thread_name(const char *name);
+void nmdi_update_dimensions(int *width, int *height, int max_pixels);
 
 #define TIME2INT64(d) llrint((d) * av_q2d(av_inv_q(AV_TIME_BASE_Q)))
 #define PTS2TIMESTR(t64) av_ts2timestr(t64, &AV_TIME_BASE_Q)
 
-#define SXPI_STATIC_ASSERT(id, c) typedef char sxpi_checking_##id[(c) ? 1 : -1]
+#define NMDI_STATIC_ASSERT(id, c) typedef char nmdi_checking_##id[(c) ? 1 : -1]
 
 #endif

--- a/src/log.c
+++ b/src/log.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -30,17 +30,17 @@ struct log_ctx {
     pthread_mutex_t lock;
     void *avlog;
     void *user_arg;
-    sxplayer_log_callback_type callback;
+    nmd_log_callback_type callback;
 };
 
-void sxpi_log_set_callback(struct log_ctx *ctx, void *arg,
-                           sxplayer_log_callback_type callback)
+void nmdi_log_set_callback(struct log_ctx *ctx, void *arg,
+                           nmd_log_callback_type callback)
 {
     ctx->user_arg = arg;
     ctx->callback = callback;
 }
 
-struct log_ctx *sxpi_log_alloc(void)
+struct log_ctx *nmdi_log_alloc(void)
 {
     struct log_ctx *ctx = av_mallocz(sizeof(*ctx));
     if (!ctx)
@@ -56,11 +56,11 @@ static void default_callback(void *arg, int level, const char *filename, int ln,
     const char *logp = logline;
     struct log_ctx *ctx = arg;
     static const int avlog_levels[] = {
-        [SXPLAYER_LOG_VERBOSE] = AV_LOG_VERBOSE,
-        [SXPLAYER_LOG_DEBUG]   = AV_LOG_DEBUG,
-        [SXPLAYER_LOG_INFO]    = AV_LOG_INFO,
-        [SXPLAYER_LOG_WARNING] = AV_LOG_WARNING,
-        [SXPLAYER_LOG_ERROR]   = AV_LOG_ERROR,
+        [NMD_LOG_VERBOSE] = AV_LOG_VERBOSE,
+        [NMD_LOG_DEBUG]   = AV_LOG_DEBUG,
+        [NMD_LOG_INFO]    = AV_LOG_INFO,
+        [NMD_LOG_WARNING] = AV_LOG_WARNING,
+        [NMD_LOG_ERROR]   = AV_LOG_ERROR,
     };
     const int avlog_level = avlog_levels[level];
     void *avlog = ctx->avlog;
@@ -102,14 +102,14 @@ static void default_callback(void *arg, int level, const char *filename, int ln,
     va_end(vl_copy);
 }
 
-int sxpi_log_init(struct log_ctx *ctx, void *avlog)
+int nmdi_log_init(struct log_ctx *ctx, void *avlog)
 {
     ctx->avlog = avlog;
-    sxpi_log_set_callback(ctx, ctx, default_callback);
+    nmdi_log_set_callback(ctx, ctx, default_callback);
     return AVERROR(pthread_mutex_init(&ctx->lock, NULL));
 }
 
-void sxpi_log_free(struct log_ctx **ctxp)
+void nmdi_log_free(struct log_ctx **ctxp)
 {
     struct log_ctx *ctx = *ctxp;
     if (!ctx)
@@ -118,7 +118,7 @@ void sxpi_log_free(struct log_ctx **ctxp)
     av_freep(ctxp);
 }
 
-void sxpi_log_print(void *log_ctx, int log_level, const char *filename,
+void nmdi_log_print(void *log_ctx, int log_level, const char *filename,
                     int ln, const char *fn, const char *fmt, ...)
 {
     va_list vl;

--- a/src/log.h
+++ b/src/log.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2016 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -23,7 +23,7 @@
 
 #include <libavutil/log.h>
 
-#include "sxplayer.h"
+#include "nopemd.h"
 
 #ifndef ENABLE_DBG
 # define ENABLE_DBG 0
@@ -39,31 +39,31 @@
 //# define LOG_LEVEL AV_LOG_DEBUG  // will log most of the important actions (get/ret frame)
 #endif
 
-#define DO_LOG(c, log_level, ...) sxpi_log_print((c)->log_ctx, log_level, \
+#define DO_LOG(c, log_level, ...) nmdi_log_print((c)->log_ctx, log_level, \
                                                  __FILE__, __LINE__, __func__, __VA_ARGS__)
 
-#define LOG(c, level, ...) DO_LOG(c, SXPLAYER_LOG_##level, __VA_ARGS__)
+#define LOG(c, level, ...) DO_LOG(c, NMD_LOG_##level, __VA_ARGS__)
 
 #if ENABLE_DBG
-#define TRACE(c, ...) do { DO_LOG(c, SXPLAYER_LOG_VERBOSE, __VA_ARGS__); fflush(stdout); } while (0)
+#define TRACE(c, ...) do { DO_LOG(c, NMD_LOG_VERBOSE, __VA_ARGS__); fflush(stdout); } while (0)
 #else
 /* Note: this could be replaced by a "while(0)" but it wouldn't test the
  * compilation of the printf format, so we use this more complex form. */
-#define TRACE(c, ...) do { if (0) DO_LOG(c, SXPLAYER_LOG_VERBOSE, __VA_ARGS__); } while (0)
+#define TRACE(c, ...) do { if (0) DO_LOG(c, NMD_LOG_VERBOSE, __VA_ARGS__); } while (0)
 #endif
 
 struct log_ctx;
 
-struct log_ctx *sxpi_log_alloc(void);
+struct log_ctx *nmdi_log_alloc(void);
 
-int sxpi_log_init(struct log_ctx *ctx, void *avlog);
+int nmdi_log_init(struct log_ctx *ctx, void *avlog);
 
-void sxpi_log_set_callback(struct log_ctx *ctx, void *arg,
-                           sxplayer_log_callback_type callback);
+void nmdi_log_set_callback(struct log_ctx *ctx, void *arg,
+                           nmd_log_callback_type callback);
 
-void sxpi_log_print(void *log_ctx, int log_level, const char *filename,
+void nmdi_log_print(void *log_ctx, int log_level, const char *filename,
                     int ln, const char *fn, const char *fmt, ...) av_printf_format(6, 7);
 
-void sxpi_log_free(struct log_ctx **ctxp);
+void nmdi_log_free(struct log_ctx **ctxp);
 
 #endif /* LOG_H */

--- a/src/mod_decoding.h
+++ b/src/mod_decoding.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -28,22 +28,22 @@
 
 #include "opts.h"
 
-struct decoding_ctx *sxpi_decoding_alloc(void);
+struct decoding_ctx *nmdi_decoding_alloc(void);
 
-int sxpi_decoding_init(void *log_ctx,
+int nmdi_decoding_init(void *log_ctx,
                        struct decoding_ctx *ctx,
                        AVThreadMessageQueue *pkt_queue,
                        AVThreadMessageQueue *frames_queue,
                        int is_image,
                        const AVStream *stream,
-                       const struct sxplayer_opts *opts);
+                       const struct nmdi_opts *opts);
 
-const AVCodecContext *sxpi_decoding_get_avctx(struct decoding_ctx *ctx);
+const AVCodecContext *nmdi_decoding_get_avctx(struct decoding_ctx *ctx);
 
-int sxpi_decoding_queue_frame(struct decoding_ctx *ctx, AVFrame *frame);
+int nmdi_decoding_queue_frame(struct decoding_ctx *ctx, AVFrame *frame);
 
-void sxpi_decoding_run(struct decoding_ctx *ctx);
+void nmdi_decoding_run(struct decoding_ctx *ctx);
 
-void sxpi_decoding_free(struct decoding_ctx **ctxp);
+void nmdi_decoding_free(struct decoding_ctx **ctxp);
 
 #endif

--- a/src/mod_demuxing.c
+++ b/src/mod_demuxing.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -40,7 +40,7 @@ struct demuxing_ctx {
     AVThreadMessageQueue *pkt_queue;
 };
 
-struct demuxing_ctx *sxpi_demuxing_alloc(void)
+struct demuxing_ctx *nmdi_demuxing_alloc(void)
 {
     struct demuxing_ctx *ctx = av_mallocz(sizeof(*ctx));
     if (!ctx)
@@ -50,7 +50,7 @@ struct demuxing_ctx *sxpi_demuxing_alloc(void)
 
 // XXX: we should probably prefer the stream duration over the format
 // duration
-int64_t sxpi_demuxing_probe_duration(const struct demuxing_ctx *ctx)
+int64_t nmdi_demuxing_probe_duration(const struct demuxing_ctx *ctx)
 {
     if (!ctx->is_image) {
         int64_t probe_duration64 = ctx->fmt_ctx->duration;
@@ -67,7 +67,7 @@ int64_t sxpi_demuxing_probe_duration(const struct demuxing_ctx *ctx)
     return AV_NOPTS_VALUE;
 }
 
-double sxpi_demuxing_probe_rotation(const struct demuxing_ctx *ctx)
+double nmdi_demuxing_probe_rotation(const struct demuxing_ctx *ctx)
 {
     AVStream *st = (AVStream *)ctx->stream; // XXX: Fix FFmpeg.
     AVDictionaryEntry *rotate_tag = av_dict_get(st->metadata, "rotate", NULL, 0);
@@ -86,22 +86,22 @@ double sxpi_demuxing_probe_rotation(const struct demuxing_ctx *ctx)
     return theta;
 }
 
-const AVStream *sxpi_demuxing_get_stream(const struct demuxing_ctx *ctx)
+const AVStream *nmdi_demuxing_get_stream(const struct demuxing_ctx *ctx)
 {
     return ctx->stream;
 }
 
-int sxpi_demuxing_is_image(const struct demuxing_ctx *ctx)
+int nmdi_demuxing_is_image(const struct demuxing_ctx *ctx)
 {
     return ctx->is_image;
 }
 
-int sxpi_demuxing_init(void *log_ctx,
+int nmdi_demuxing_init(void *log_ctx,
                        struct demuxing_ctx *ctx,
                        AVThreadMessageQueue *src_queue,
                        AVThreadMessageQueue *pkt_queue,
                        const char *filename,
-                       const struct sxplayer_opts *opts)
+                       const struct nmdi_opts *opts)
 {
     enum AVMediaType media_type;
 
@@ -112,8 +112,8 @@ int sxpi_demuxing_init(void *log_ctx,
     ctx->pkt_skip_mod = opts->pkt_skip_mod;
 
     switch (opts->avselect) {
-    case SXPLAYER_SELECT_VIDEO: media_type = AVMEDIA_TYPE_VIDEO; break;
-    case SXPLAYER_SELECT_AUDIO: media_type = AVMEDIA_TYPE_AUDIO; break;
+    case NMD_SELECT_VIDEO: media_type = AVMEDIA_TYPE_VIDEO; break;
+    case NMD_SELECT_AUDIO: media_type = AVMEDIA_TYPE_AUDIO; break;
     default:
         av_assert0(0);
     }
@@ -190,7 +190,7 @@ static int pull_packet(struct demuxing_ctx *ctx, AVPacket *pkt)
     return ret;
 }
 
-void sxpi_demuxing_run(struct demuxing_ctx *ctx)
+void nmdi_demuxing_run(struct demuxing_ctx *ctx)
 {
     int ret;
     int in_err, out_err;
@@ -218,7 +218,7 @@ void sxpi_demuxing_run(struct demuxing_ctx *ctx)
                 LOG(ctx, INFO, "Seek in media at ts=%s", PTS2TIMESTR(seek_to));
                 ret = avformat_seek_file(ctx->fmt_ctx, -1, INT64_MIN, seek_to, seek_to, 0);
                 if (ret < 0) {
-                    sxpi_msg_free_data(&msg);
+                    nmdi_msg_free_data(&msg);
                     break;
                 }
             }
@@ -226,7 +226,7 @@ void sxpi_demuxing_run(struct demuxing_ctx *ctx)
             /* Forward the message */
             ret = av_thread_message_queue_send(ctx->pkt_queue, &msg, 0);
             if (ret < 0) {
-                sxpi_msg_free_data(&msg);
+                nmdi_msg_free_data(&msg);
                 break;
             }
         }
@@ -272,7 +272,7 @@ void sxpi_demuxing_run(struct demuxing_ctx *ctx)
     av_thread_message_queue_set_err_recv(ctx->pkt_queue, out_err);
 }
 
-void sxpi_demuxing_free(struct demuxing_ctx **ctxp)
+void nmdi_demuxing_free(struct demuxing_ctx **ctxp)
 {
     struct demuxing_ctx *ctx = *ctxp;
     if (!ctx)

--- a/src/mod_demuxing.h
+++ b/src/mod_demuxing.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -27,22 +27,22 @@
 
 #include "opts.h"
 
-struct demuxing_ctx *sxpi_demuxing_alloc(void);
+struct demuxing_ctx *nmdi_demuxing_alloc(void);
 
-int sxpi_demuxing_init(void *log_ctx,
+int nmdi_demuxing_init(void *log_ctx,
                        struct demuxing_ctx *ctx,
                        AVThreadMessageQueue *src_queue,
                        AVThreadMessageQueue *pkt_queue,
                        const char *filename,
-                       const struct sxplayer_opts *opts);
+                       const struct nmdi_opts *opts);
 
-int64_t sxpi_demuxing_probe_duration(const struct demuxing_ctx *ctx);
-double sxpi_demuxing_probe_rotation(const struct demuxing_ctx *ctx);
-const AVStream *sxpi_demuxing_get_stream(const struct demuxing_ctx *ctx);
-int sxpi_demuxing_is_image(const struct demuxing_ctx *ctx);
+int64_t nmdi_demuxing_probe_duration(const struct demuxing_ctx *ctx);
+double nmdi_demuxing_probe_rotation(const struct demuxing_ctx *ctx);
+const AVStream *nmdi_demuxing_get_stream(const struct demuxing_ctx *ctx);
+int nmdi_demuxing_is_image(const struct demuxing_ctx *ctx);
 
-void sxpi_demuxing_run(struct demuxing_ctx *ctx);
+void nmdi_demuxing_run(struct demuxing_ctx *ctx);
 
-void sxpi_demuxing_free(struct demuxing_ctx **ctxp);
+void nmdi_demuxing_free(struct demuxing_ctx **ctxp);
 
 #endif

--- a/src/mod_filtering.c
+++ b/src/mod_filtering.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -29,7 +29,7 @@
 #include <libavutil/pixdesc.h>
 #include <libavutil/timestamp.h>
 
-#include "sxplayer.h"
+#include "nopemd.h"
 #include "internal.h"
 #include "mod_filtering.h"
 #include "log.h"
@@ -62,7 +62,7 @@ struct filtering_ctx {
     FFTSample *rdft_data[AUDIO_NBCHANNELS]; // real discrete fourier transform data for each channel
 };
 
-struct filtering_ctx *sxpi_filtering_alloc(void)
+struct filtering_ctx *nmdi_filtering_alloc(void)
 {
     struct filtering_ctx *ctx = av_mallocz(sizeof(*ctx));
     if (!ctx)
@@ -248,9 +248,9 @@ static int setup_filtergraph(struct filtering_ctx *ctx)
     snprintf(args, sizeof(args), "sws_flags=+full_chroma_int;%s", ctx->filters ? ctx->filters : "");
     if (codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
         const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(ctx->last_frame_format);
-        enum AVPixelFormat sw_pix_fmt = sxpi_pix_fmts_sx2ff(ctx->sw_pix_fmt);
-        if (ctx->sw_pix_fmt == SXPLAYER_PIXFMT_AUTO) {
-            const enum sxplayer_pixel_format fmt = sxpi_pix_fmts_ff2sx(ctx->last_frame_format);
+        enum AVPixelFormat sw_pix_fmt = nmdi_pix_fmts_nmd2ff(ctx->sw_pix_fmt);
+        if (ctx->sw_pix_fmt == NMD_PIXFMT_AUTO) {
+            const enum nmd_pixel_format fmt = nmdi_pix_fmts_ff2nmd(ctx->last_frame_format);
             if (fmt == -1) {
                 LOG(ctx, DEBUG, "Unsupported software pixel format: %s, falling back to rgba",
                     av_get_pix_fmt_name(ctx->last_frame_format));
@@ -263,7 +263,7 @@ static int setup_filtergraph(struct filtering_ctx *ctx)
 
         if (ctx->max_pixels) {
             int w = codecpar->width, h = codecpar->height;
-            sxpi_update_dimensions(&w, &h, ctx->max_pixels);
+            nmdi_update_dimensions(&w, &h, ctx->max_pixels);
             av_strlcatf(args, sizeof(args),
                         "%sscale=%d:%d:force_original_aspect_ratio=decrease",
                         SEP(args), w, h);
@@ -337,14 +337,14 @@ static char *update_filters_str(char *filters, const char *append)
     return str;
 }
 
-int sxpi_filtering_init(void *log_ctx,
+int nmdi_filtering_init(void *log_ctx,
                         struct filtering_ctx *ctx,
                         AVThreadMessageQueue *in_queue,
                         AVThreadMessageQueue *out_queue,
                         const AVStream *stream,
                         const AVCodecContext *avctx,
                         double media_rotation,
-                        const struct sxplayer_opts *o)
+                        const struct nmdi_opts *o)
 {
     ctx->log_ctx = log_ctx;
     ctx->in_queue  = in_queue;
@@ -517,7 +517,7 @@ static int flush_frames(struct filtering_ctx *ctx)
     return ret;
 }
 
-void sxpi_filtering_run(struct filtering_ctx *ctx)
+void nmdi_filtering_run(struct filtering_ctx *ctx)
 {
     int ret;
     int in_err, out_err;
@@ -546,7 +546,7 @@ void sxpi_filtering_run(struct filtering_ctx *ctx)
             av_thread_message_flush(ctx->out_queue);
             ret = av_thread_message_queue_send(ctx->out_queue, &msg, 0);
             if (ret < 0) {
-                sxpi_msg_free_data(&msg);
+                nmdi_msg_free_data(&msg);
                 break;
             }
             continue;
@@ -617,7 +617,7 @@ void sxpi_filtering_run(struct filtering_ctx *ctx)
     av_thread_message_queue_set_err_recv(ctx->out_queue, out_err);
 }
 
-void sxpi_filtering_free(struct filtering_ctx **fp)
+void nmdi_filtering_free(struct filtering_ctx **fp)
 {
     struct filtering_ctx *ctx = *fp;
 

--- a/src/mod_filtering.h
+++ b/src/mod_filtering.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -26,19 +26,19 @@
 
 #include "opts.h"
 
-struct filtering_ctx *sxpi_filtering_alloc(void);
+struct filtering_ctx *nmdi_filtering_alloc(void);
 
-int sxpi_filtering_init(void *log_ctx,
+int nmdi_filtering_init(void *log_ctx,
                         struct filtering_ctx *ctx,
                         AVThreadMessageQueue *in_queue,
                         AVThreadMessageQueue *out_queue,
                         const AVStream *stream,
                         const AVCodecContext *avctx,
                         double media_rotation,
-                        const struct sxplayer_opts *o);
+                        const struct nmdi_opts *o);
 
-void sxpi_filtering_run(struct filtering_ctx *ctx);
+void nmdi_filtering_run(struct filtering_ctx *ctx);
 
-void sxpi_filtering_free(struct filtering_ctx **ctxp);
+void nmdi_filtering_free(struct filtering_ctx **ctxp);
 
 #endif

--- a/src/msg.c
+++ b/src/msg.c
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2016 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -24,7 +24,7 @@
 
 #include "msg.h"
 
-void sxpi_msg_free_data(void *arg)
+void nmdi_msg_free_data(void *arg)
 {
     struct message *msg = arg;
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2016 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -37,6 +37,6 @@ struct message {
     enum msg_type type;
 };
 
-void sxpi_msg_free_data(void *arg);
+void nmdi_msg_free_data(void *arg);
 
 #endif

--- a/src/nopemd.h.in
+++ b/src/nopemd.h.in
@@ -1,52 +1,48 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef SXPLAYER_H
-#define SXPLAYER_H
+#ifndef NOPE_MEDIA_H
+#define NOPE_MEDIA_H
 
 #include <stdint.h>
 #include <stdarg.h>
 
-#define SXPLAYER_VERSION_MAJOR @version_major@
-#define SXPLAYER_VERSION_MINOR @version_minor@
-#define SXPLAYER_VERSION_MICRO @version_micro@
+#define NMD_VERSION_MAJOR @version_major@
+#define NMD_VERSION_MINOR @version_minor@
+#define NMD_VERSION_MICRO @version_micro@
 
-#define SXPLAYER_GET_VERSION(major, minor, micro) ((major)<<16 | (minor)<<8 | (micro))
+#define NMD_GET_VERSION(major, minor, micro) ((major)<<16 | (minor)<<8 | (micro))
 
-#define SXPLAYER_VERSION_INT SXPLAYER_GET_VERSION(SXPLAYER_VERSION_MAJOR, \
-                                                  SXPLAYER_VERSION_MINOR, \
-                                                  SXPLAYER_VERSION_MICRO)
+#define NMD_VERSION_INT NMD_GET_VERSION(NMD_VERSION_MAJOR, NMD_VERSION_MINOR, NMD_VERSION_MICRO)
 
 #if defined(_WIN32)
-#  if defined(BUILD_SXPLAYER_SHARED_LIB) /* On Windows, we need to export the symbols while building */
-#    define SXAPI __declspec(dllexport)
-#  elif defined(USE_SXPLAYER_STATIC_LIB) /* Static library users don't need anything special */
-#    define SXAPI
+#  if defined(BUILD_NOPE_MEDIA_SHARED_LIB) /* On Windows, we need to export the symbols while building */
+#    define NMDAPI __declspec(dllexport)
+#  elif defined(USE_NOPE_MEDIA_STATIC_LIB) /* Static library users don't need anything special */
+#    define NMDAPI
 #  else
-#    define SXAPI __declspec(dllimport)  /* Dynamic library users (default) need a DLL import spec */
+#    define NMDAPI __declspec(dllimport)  /* Dynamic library users (default) need a DLL import spec */
 #  endif
 #else
-#  define SXAPI __attribute__((visibility("default"))) /* This cancel the hidden GNU symbol visibility attribute */
+#  define NMDAPI __attribute__((visibility("default"))) /* This cancel the hidden GNU symbol visibility attribute */
 #endif
-
-/* Stupeflix Media Player */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
@@ -73,109 +69,109 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-struct sxplayer_ctx;
+struct nmd_ctx;
 
-enum sxplayer_media_selection {
-    SXPLAYER_SELECT_VIDEO,
-    SXPLAYER_SELECT_AUDIO,
-    NB_SXPLAYER_MEDIA_SELECTION // *NOT* part of the API/ABI
+enum nmd_media_selection {
+    NMD_SELECT_VIDEO,
+    NMD_SELECT_AUDIO,
+    NB_NMD_MEDIA_SELECTION // *NOT* part of the API/ABI
 };
 
-enum sxplayer_pixel_format {
-    SXPLAYER_PIXFMT_NONE = -1,
-    SXPLAYER_PIXFMT_RGBA,
-    SXPLAYER_PIXFMT_BGRA,
-    SXPLAYER_PIXFMT_VT,        // VideoToolBox pixel format (HW accelerated, frame->data/frame->datap[0] is a CVPixelBufferRef)
-    SXPLAYER_PIXFMT_MEDIACODEC,// MediaCodec pixel format (HW accelerated, frame->data/frame->datap[0] is a AVMediaCodecBuffer)
-    SXPLAYER_SMPFMT_FLT,
-    SXPLAYER_PIXFMT_VAAPI,     // VAAPI pixel format (HW accelerated, frame->data/frame->datap[0] is a VASurfaceID)
-    SXPLAYER_PIXFMT_AUTO,
-    SXPLAYER_PIXFMT_NV12,
-    SXPLAYER_PIXFMT_YUV420P,
-    SXPLAYER_PIXFMT_YUV422P,
-    SXPLAYER_PIXFMT_YUV444P,
-    SXPLAYER_PIXFMT_P010LE,
-    SXPLAYER_PIXFMT_YUV420P10LE,
-    SXPLAYER_PIXFMT_YUV422P10LE,
-    SXPLAYER_PIXFMT_YUV444P10LE,
+enum nmd_pixel_format {
+    NMD_PIXFMT_NONE = -1,
+    NMD_PIXFMT_RGBA,
+    NMD_PIXFMT_BGRA,
+    NMD_PIXFMT_VT,        // VideoToolBox pixel format (HW accelerated, frame->data/frame->datap[0] is a CVPixelBufferRef)
+    NMD_PIXFMT_MEDIACODEC,// MediaCodec pixel format (HW accelerated, frame->data/frame->datap[0] is a AVMediaCodecBuffer)
+    NMD_SMPFMT_FLT,
+    NMD_PIXFMT_VAAPI,     // VAAPI pixel format (HW accelerated, frame->data/frame->datap[0] is a VASurfaceID)
+    NMD_PIXFMT_AUTO,
+    NMD_PIXFMT_NV12,
+    NMD_PIXFMT_YUV420P,
+    NMD_PIXFMT_YUV422P,
+    NMD_PIXFMT_YUV444P,
+    NMD_PIXFMT_P010LE,
+    NMD_PIXFMT_YUV420P10LE,
+    NMD_PIXFMT_YUV422P10LE,
+    NMD_PIXFMT_YUV444P10LE,
 };
 
-enum sxplayer_loglevel {
-    SXPLAYER_LOG_VERBOSE,
-    SXPLAYER_LOG_DEBUG,
-    SXPLAYER_LOG_INFO,
-    SXPLAYER_LOG_WARNING,
-    SXPLAYER_LOG_ERROR,
-};
-
-enum {
-    SXPLAYER_COL_SPC_RGB,
-    SXPLAYER_COL_SPC_BT709,
-    SXPLAYER_COL_SPC_UNSPECIFIED,
-    SXPLAYER_COL_SPC_RESERVED,
-    SXPLAYER_COL_SPC_FCC,
-    SXPLAYER_COL_SPC_BT470BG,
-    SXPLAYER_COL_SPC_SMPTE170M,
-    SXPLAYER_COL_SPC_SMPTE240M,
-    SXPLAYER_COL_SPC_YCGCO,
-    SXPLAYER_COL_SPC_BT2020_NCL,
-    SXPLAYER_COL_SPC_BT2020_CL,
-    SXPLAYER_COL_SPC_SMPTE2085,
-    SXPLAYER_COL_SPC_CHROMA_DERIVED_NCL,
-    SXPLAYER_COL_SPC_CHROMA_DERIVED_CL,
-    SXPLAYER_COL_SPC_ICTCP,
-    NB_SXPLAYER_COL_SPC // *NOT* part of API/ABI
+enum nmd_loglevel {
+    NMD_LOG_VERBOSE,
+    NMD_LOG_DEBUG,
+    NMD_LOG_INFO,
+    NMD_LOG_WARNING,
+    NMD_LOG_ERROR,
 };
 
 enum {
-    SXPLAYER_COL_RNG_UNSPECIFIED,
-    SXPLAYER_COL_RNG_LIMITED,
-    SXPLAYER_COL_RNG_FULL,
-    NB_SXPLAYER_COL_RNG // *NOT* part of API/ABI
+    NMD_COL_SPC_RGB,
+    NMD_COL_SPC_BT709,
+    NMD_COL_SPC_UNSPECIFIED,
+    NMD_COL_SPC_RESERVED,
+    NMD_COL_SPC_FCC,
+    NMD_COL_SPC_BT470BG,
+    NMD_COL_SPC_SMPTE170M,
+    NMD_COL_SPC_SMPTE240M,
+    NMD_COL_SPC_YCGCO,
+    NMD_COL_SPC_BT2020_NCL,
+    NMD_COL_SPC_BT2020_CL,
+    NMD_COL_SPC_SMPTE2085,
+    NMD_COL_SPC_CHROMA_DERIVED_NCL,
+    NMD_COL_SPC_CHROMA_DERIVED_CL,
+    NMD_COL_SPC_ICTCP,
+    NB_NMD_COL_SPC // *NOT* part of API/ABI
 };
 
 enum {
-    SXPLAYER_COL_PRI_RESERVED0,
-    SXPLAYER_COL_PRI_BT709,
-    SXPLAYER_COL_PRI_UNSPECIFIED,
-    SXPLAYER_COL_PRI_RESERVED,
-    SXPLAYER_COL_PRI_BT470M,
-    SXPLAYER_COL_PRI_BT470BG,
-    SXPLAYER_COL_PRI_SMPTE170M,
-    SXPLAYER_COL_PRI_SMPTE240M,
-    SXPLAYER_COL_PRI_FILM,
-    SXPLAYER_COL_PRI_BT2020,
-    SXPLAYER_COL_PRI_SMPTE428,
-    SXPLAYER_COL_PRI_SMPTE431,
-    SXPLAYER_COL_PRI_SMPTE432,
-    SXPLAYER_COL_PRI_JEDEC_P22,
-    NB_SXPLAYER_COL_PRI // *NOT* part of API/ABI
+    NMD_COL_RNG_UNSPECIFIED,
+    NMD_COL_RNG_LIMITED,
+    NMD_COL_RNG_FULL,
+    NB_NMD_COL_RNG // *NOT* part of API/ABI
 };
 
 enum {
-    SXPLAYER_COL_TRC_RESERVED0,
-    SXPLAYER_COL_TRC_BT709,
-    SXPLAYER_COL_TRC_UNSPECIFIED,
-    SXPLAYER_COL_TRC_RESERVED,
-    SXPLAYER_COL_TRC_GAMMA22,
-    SXPLAYER_COL_TRC_GAMMA28,
-    SXPLAYER_COL_TRC_SMPTE170M,
-    SXPLAYER_COL_TRC_SMPTE240M,
-    SXPLAYER_COL_TRC_LINEAR,
-    SXPLAYER_COL_TRC_LOG,
-    SXPLAYER_COL_TRC_LOG_SQRT,
-    SXPLAYER_COL_TRC_IEC61966_2_4,
-    SXPLAYER_COL_TRC_BT1361_ECG,
-    SXPLAYER_COL_TRC_IEC61966_2_1,
-    SXPLAYER_COL_TRC_BT2020_10,
-    SXPLAYER_COL_TRC_BT2020_12,
-    SXPLAYER_COL_TRC_SMPTE2084,
-    SXPLAYER_COL_TRC_SMPTE428,
-    SXPLAYER_COL_TRC_ARIB_STD_B67,
-    NB_SXPLAYER_COL_TRC // *NOT* part of the API/ABI
+    NMD_COL_PRI_RESERVED0,
+    NMD_COL_PRI_BT709,
+    NMD_COL_PRI_UNSPECIFIED,
+    NMD_COL_PRI_RESERVED,
+    NMD_COL_PRI_BT470M,
+    NMD_COL_PRI_BT470BG,
+    NMD_COL_PRI_SMPTE170M,
+    NMD_COL_PRI_SMPTE240M,
+    NMD_COL_PRI_FILM,
+    NMD_COL_PRI_BT2020,
+    NMD_COL_PRI_SMPTE428,
+    NMD_COL_PRI_SMPTE431,
+    NMD_COL_PRI_SMPTE432,
+    NMD_COL_PRI_JEDEC_P22,
+    NB_NMD_COL_PRI // *NOT* part of API/ABI
 };
 
-struct sxplayer_frame {
+enum {
+    NMD_COL_TRC_RESERVED0,
+    NMD_COL_TRC_BT709,
+    NMD_COL_TRC_UNSPECIFIED,
+    NMD_COL_TRC_RESERVED,
+    NMD_COL_TRC_GAMMA22,
+    NMD_COL_TRC_GAMMA28,
+    NMD_COL_TRC_SMPTE170M,
+    NMD_COL_TRC_SMPTE240M,
+    NMD_COL_TRC_LINEAR,
+    NMD_COL_TRC_LOG,
+    NMD_COL_TRC_LOG_SQRT,
+    NMD_COL_TRC_IEC61966_2_4,
+    NMD_COL_TRC_BT1361_ECG,
+    NMD_COL_TRC_IEC61966_2_1,
+    NMD_COL_TRC_BT2020_10,
+    NMD_COL_TRC_BT2020_12,
+    NMD_COL_TRC_SMPTE2084,
+    NMD_COL_TRC_SMPTE428,
+    NMD_COL_TRC_ARIB_STD_B67,
+    NB_NMD_COL_TRC // *NOT* part of the API/ABI
+};
+
+struct nmd_frame {
     uint8_t *data;      // frame data in RGBA, BGRA, ... according to pix_fmt. Deprecated, use datap instead
     double ts;          // video timestamp
     int linesize;       // linesize in bytes (includes padding). Deprecated, use linesizep instead
@@ -184,21 +180,21 @@ struct sxplayer_frame {
     int nb_samples;     // number of audio samples contained in the frame
     };
     int height;         // frame height in pixel
-    int pix_fmt;        // sxplayer_pixel_format
+    int pix_fmt;        // nmd_pixel_format
     void *mvs;          // motions vectors (AVMotionVector*)
     int nb_mvs;         // number of motions vectors
     int64_t ms;         // video timestamp in microseconds
     int64_t pts;        // video presentation time stamp in stream timebase unit
-    void *internal;     // sxplayer internal frame context frame, do not alter
-    int color_space;    // video color space (any of SXPLAYER_COL_CSP_*)
-    int color_range;    // video color range (any of SXPLAYER_COL_RNG_*)
-    int color_primaries;// video color primaries (any of SXPLAYER_COL_PRI_*)
-    int color_trc;      // video color transfer (any of SXPLAYER_COL_TRC_*)
+    void *internal;     // nmd internal frame context frame, do not alter
+    int color_space;    // video color space (any of NMD_COL_CSP_*)
+    int color_range;    // video color range (any of NMD_COL_RNG_*)
+    int color_primaries;// video color primaries (any of NMD_COL_PRI_*)
+    int color_trc;      // video color transfer (any of NMD_COL_TRC_*)
     uint8_t *datap[8];  // pointer to the frame planes
     int linesizep[8];   // linesize in bytes of each planes
 };
 
-struct sxplayer_info {
+struct nmd_info {
     int width;
     int height;
     double duration;
@@ -211,21 +207,21 @@ struct sxplayer_info {
  *
  * @param filename media input file name
  */
-SXAPI struct sxplayer_ctx *sxplayer_create(const char *filename);
+NMDAPI struct nmd_ctx *nmd_create(const char *filename);
 
 /**
  * Type of the user log callback
  *
  * @param arg       opaque user argument
- * @param level     log level of the message (SXPLAYER_LOG_*)
+ * @param level     log level of the message (NMD_LOG_*)
  * @param filename  source filename
  * @param ln        line number in the source file
  * @param fn        function name in the source
  * @param fmt       log string format
  * @param vl        variable argument list associated with the format
  */
-typedef void (*sxplayer_log_callback_type)(void *arg, int level, const char *filename,
-                                           int ln, const char *fn, const char *fmt, va_list vl);
+typedef void (*nmd_log_callback_type)(void *arg, int level, const char *filename,
+                                      int ln, const char *fn, const char *fmt, va_list vl);
 
 /**
  * Set user logging callback
@@ -238,7 +234,7 @@ typedef void (*sxplayer_log_callback_type)(void *arg, int level, const char *fil
  *                  the callback
  * @param callback  custom user logging callback
  */
-SXAPI void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer_log_callback_type callback);
+NMDAPI void nmd_set_log_callback(struct nmd_ctx *s, void *arg, nmd_log_callback_type callback);
 
 /**
  * Set an option.
@@ -247,7 +243,7 @@ SXAPI void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer
  *
  *   key                      type      description
  *   ----------------------------------------------
- *   avselect                 integer   select audio or video stream (see SXPLAYER_SELECT_*)
+ *   avselect                 integer   select audio or video stream (see NMD_SELECT_*)
  *   start_time               double    start time of the video
  *   end_time                 double    end time of the video
  *   skip                     double    alias for start_time (deprecated)
@@ -256,11 +252,11 @@ SXAPI void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer
  *   max_nb_frames            integer   maximum number of frames in the queue
  *   filters                  string    custom user filters (software decoding only)
  *   sw_pix_fmt               integer   pixel format format to use when using software decoding (video only),
- *                                      can be any SXPLAYER_PIXFMT_* not HW accelerated. If sw_pix_fmt is set
- *                                      to SXPLAYER_PIXFMT_AUTO, sxplayer automatically selects a pixel format
+ *                                      can be any NMD_PIXFMT_* not HW accelerated. If sw_pix_fmt is set
+ *                                      to NMD_PIXFMT_AUTO, nope.media automatically selects a pixel format
  *                                      based on the intersection between the decoder output pixel format and
- *                                      the list of non-HW accelerated formats supported by sxplayer (SXPLAYER_PIXFMT_*).
- *                                      If the decoder output format is not supported, sxplayer fallbacks to RGBA.
+ *                                      the list of non-HW accelerated formats supported by nope.media (NMD_PIXFMT_*).
+ *                                      If the decoder output format is not supported, nope.media fallbacks to RGBA.
  *   autorotate               integer   automatically insert rotation filters (video software decoding only)
  *   auto_hwaccel             integer   attempt to enable hardware acceleration
  *   export_mvs               integer   export motion vectors into frame->mvs
@@ -273,28 +269,28 @@ SXAPI void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer
  *   stream_idx               integer   force a stream number instead of picking the "best" one (note: stream MUST be of type avselect)
  *   use_pkt_duration         integer   use packet duration instead of decoding the next frame to get the next frame pts
  */
-SXAPI int sxplayer_set_option(struct sxplayer_ctx *s, const char *key, ...);
+NMDAPI int nmd_set_option(struct nmd_ctx *s, const char *key, ...);
 
 /**
  * Get the media duration (clipped to end_time if set).
  *
  * The duration is expressed in seconds.
  */
-SXAPI int sxplayer_get_duration(struct sxplayer_ctx *s, double *duration);
+NMDAPI int nmd_get_duration(struct nmd_ctx *s, double *duration);
 
 /**
  * Get various information on the media.
  */
-SXAPI int sxplayer_get_info(struct sxplayer_ctx *s, struct sxplayer_info *info);
+NMDAPI int nmd_get_info(struct nmd_ctx *s, struct nmd_info *info);
 
 /**
  * Get the frame at an absolute time.
  *
  * The returned frame can be NULL if unchanged from last call.
  *
- * The returned frame needs to be released using sxplayer_release_frame().
+ * The returned frame needs to be released using nmd_release_frame().
  *
- * Requesting a negative time is equivalent to calling sxplayer_prefetch().
+ * Requesting a negative time is equivalent to calling nmd_prefetch().
  *
  * If you are working on a player (which typically needs seeking and has a
  * refresh rate architecture), this is the function you are probably interested
@@ -303,12 +299,12 @@ SXAPI int sxplayer_get_info(struct sxplayer_ctx *s, struct sxplayer_info *info);
  * The function is blocking, it will make sure any asynchronous operation
  * previously requested (start, seek, stop) is honored before returning.
  */
-SXAPI struct sxplayer_frame *sxplayer_get_frame(struct sxplayer_ctx *s, double t);
+NMDAPI struct nmd_frame *nmd_get_frame(struct nmd_ctx *s, double t);
 
 /**
- * Same as sxplayer_get_frame, but with timestamp expressed in microseconds.
+ * Same as nmd_get_frame, but with timestamp expressed in microseconds.
  */
-SXAPI struct sxplayer_frame *sxplayer_get_frame_ms(struct sxplayer_ctx *s, int64_t ms);
+NMDAPI struct nmd_frame *nmd_get_frame_ms(struct nmd_ctx *s, int64_t ms);
 
 /**
  * Request a playback start to the player.
@@ -318,7 +314,7 @@ SXAPI struct sxplayer_frame *sxplayer_get_frame_ms(struct sxplayer_ctx *s, int64
  *
  * Return 0 on success, a negative value on error.
  */
-SXAPI int sxplayer_start(struct sxplayer_ctx *s);
+NMDAPI int nmd_start(struct nmd_ctx *s);
 
 /**
  * Request a stop to the player to liberate playback ressources.
@@ -328,7 +324,7 @@ SXAPI int sxplayer_start(struct sxplayer_ctx *s);
  *
  * Return 0 on success, a negative value on error.
  */
-SXAPI int sxplayer_stop(struct sxplayer_ctx *s);
+NMDAPI int nmd_stop(struct nmd_ctx *s);
 
 /**
  * Request a seek to the player at a given time.
@@ -340,30 +336,30 @@ SXAPI int sxplayer_stop(struct sxplayer_ctx *s);
  *
  * Return 0 on success, a negative value on error.
  */
-SXAPI int sxplayer_seek(struct sxplayer_ctx *s, double t);
+NMDAPI int nmd_seek(struct nmd_ctx *s, double t);
 
 /**
  * Get the next frame.
  *
- * The returned frame needs to be released using sxplayer_release_frame().
+ * The returned frame needs to be released using nmd_release_frame().
  *
- * At EOF sxplayer_get_next_frame() will return NULL. You can call
- * sxplayer_get_next_frame() to restart the decoding from the beginning.
+ * At EOF nmd_get_next_frame() will return NULL. You can call
+ * nmd_get_next_frame() to restart the decoding from the beginning.
  *
  * If you want to process every single frame of the media regardless of a
  * "refresh rate" or seeking needs, this is the function you are probably
  * interested in. You can still use this function in combination with
- * sxplayer_get_frame() in case you need seeking.
+ * nmd_get_frame() in case you need seeking.
  */
-SXAPI struct sxplayer_frame *sxplayer_get_next_frame(struct sxplayer_ctx *s);
+NMDAPI struct nmd_frame *nmd_get_next_frame(struct nmd_ctx *s);
 
 /* Enable or disable the droping of non reference frames */
-SXAPI int sxplayer_set_drop_ref(struct sxplayer_ctx *s, int drop);
+NMDAPI int nmd_set_drop_ref(struct nmd_ctx *s, int drop);
 
-/* Release a frame obtained with sxplayer_get_frame() */
-SXAPI void sxplayer_release_frame(struct sxplayer_frame *frame);
+/* Release a frame obtained with nmd_get_frame() */
+NMDAPI void nmd_release_frame(struct nmd_frame *frame);
 
 /* Close and free everything */
-SXAPI void sxplayer_free(struct sxplayer_ctx **ss);
+NMDAPI void nmd_free(struct nmd_ctx **ss);
 
 #endif

--- a/src/nopemd.hpp
+++ b/src/nopemd.hpp
@@ -1,0 +1,4 @@
+#warning "nope.media is a C library and C++ is not officially supported"
+extern "C" {
+#include "nopemd.h"
+}

--- a/src/opts.h
+++ b/src/opts.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2016 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
@@ -23,7 +23,7 @@
 
 #include <stdint.h>
 
-struct sxplayer_opts {
+struct nmdi_opts {
     int avselect;                           // select audio or video
     double start_time;                      // see public header
     double end_time;                        // see public header
@@ -34,7 +34,7 @@ struct sxplayer_opts {
     int max_nb_packets;                     // maximum number of packets in the queue
     int max_nb_sink;                        // maximum number of frames in the filtered queue
     char *filters;                          // user filter graph string
-    int sw_pix_fmt;                         // sx pixel format to use for software decoding
+    int sw_pix_fmt;                         // node.media pixel format to use for software decoding
     int autorotate;                         // switch for automatically rotate in software decoding
     int auto_hwaccel;                       // attempt to enable hardware acceleration
     int export_mvs;                         // export motion vectors into frame->mvs

--- a/src/pthread_compat.h
+++ b/src/pthread_compat.h
@@ -1,20 +1,20 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2021 GoPro
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 

--- a/src/sxplayer.hpp
+++ b/src/sxplayer.hpp
@@ -1,4 +1,0 @@
-#warning "sxplayer is a C library and C++ is not officially supported"
-extern "C" {
-#include "sxplayer.h"
-}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,83 +1,83 @@
 /*
- * This file is part of sxplayer.
+ * This file is part of nope.media.
  *
  * Copyright (c) 2015 Stupeflix
  *
- * sxplayer is free software; you can redistribute it and/or
+ * nope.media is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
  *
- * sxplayer is distributed in the hope that it will be useful,
+ * nope.media is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with sxplayer; if not, write to the Free Software
+ * License along with nope.media; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #define _GNU_SOURCE // pthread_setname_np on Linux
 
-#include "sxplayer.h"
+#include "nopemd.h"
 #include "internal.h"
 #include "pthread_compat.h"
 
 static const struct {
     enum AVPixelFormat ff;
-    enum sxplayer_pixel_format sx;
+    enum nmd_pixel_format nmd;
 } pix_fmts_mapping[] = {
-    {AV_PIX_FMT_MEDIACODEC,   SXPLAYER_PIXFMT_MEDIACODEC},
-    {AV_PIX_FMT_VAAPI,        SXPLAYER_PIXFMT_VAAPI},
-    {AV_PIX_FMT_VIDEOTOOLBOX, SXPLAYER_PIXFMT_VT},
-    {AV_PIX_FMT_BGRA,         SXPLAYER_PIXFMT_BGRA},
-    {AV_PIX_FMT_RGBA,         SXPLAYER_PIXFMT_RGBA},
-    {AV_PIX_FMT_NV12,         SXPLAYER_PIXFMT_NV12},
-    {AV_PIX_FMT_YUV420P,      SXPLAYER_PIXFMT_YUV420P},
-    {AV_PIX_FMT_YUVJ420P,     SXPLAYER_PIXFMT_YUV420P},
-    {AV_PIX_FMT_YUV422P,      SXPLAYER_PIXFMT_YUV422P},
-    {AV_PIX_FMT_YUVJ422P,     SXPLAYER_PIXFMT_YUV422P},
-    {AV_PIX_FMT_YUV444P,      SXPLAYER_PIXFMT_YUV444P},
-    {AV_PIX_FMT_YUVJ444P,     SXPLAYER_PIXFMT_YUV444P},
-    {AV_PIX_FMT_P010LE,       SXPLAYER_PIXFMT_P010LE},
-    {AV_PIX_FMT_YUV420P10LE,  SXPLAYER_PIXFMT_YUV420P10LE},
-    {AV_PIX_FMT_YUV422P10LE,  SXPLAYER_PIXFMT_YUV422P10LE},
-    {AV_PIX_FMT_YUV444P10LE,  SXPLAYER_PIXFMT_YUV444P10LE},
+    {AV_PIX_FMT_MEDIACODEC,   NMD_PIXFMT_MEDIACODEC},
+    {AV_PIX_FMT_VAAPI,        NMD_PIXFMT_VAAPI},
+    {AV_PIX_FMT_VIDEOTOOLBOX, NMD_PIXFMT_VT},
+    {AV_PIX_FMT_BGRA,         NMD_PIXFMT_BGRA},
+    {AV_PIX_FMT_RGBA,         NMD_PIXFMT_RGBA},
+    {AV_PIX_FMT_NV12,         NMD_PIXFMT_NV12},
+    {AV_PIX_FMT_YUV420P,      NMD_PIXFMT_YUV420P},
+    {AV_PIX_FMT_YUVJ420P,     NMD_PIXFMT_YUV420P},
+    {AV_PIX_FMT_YUV422P,      NMD_PIXFMT_YUV422P},
+    {AV_PIX_FMT_YUVJ422P,     NMD_PIXFMT_YUV422P},
+    {AV_PIX_FMT_YUV444P,      NMD_PIXFMT_YUV444P},
+    {AV_PIX_FMT_YUVJ444P,     NMD_PIXFMT_YUV444P},
+    {AV_PIX_FMT_P010LE,       NMD_PIXFMT_P010LE},
+    {AV_PIX_FMT_YUV420P10LE,  NMD_PIXFMT_YUV420P10LE},
+    {AV_PIX_FMT_YUV422P10LE,  NMD_PIXFMT_YUV422P10LE},
+    {AV_PIX_FMT_YUV444P10LE,  NMD_PIXFMT_YUV444P10LE},
 };
 
 static const struct {
     enum AVSampleFormat ff;
-    enum sxplayer_pixel_format sx;
+    enum nmd_pixel_format nmd;
 } smp_fmts_mapping[] = {
-    {AV_SAMPLE_FMT_FLT,       SXPLAYER_SMPFMT_FLT},
+    {AV_SAMPLE_FMT_FLT,       NMD_SMPFMT_FLT},
 };
 
-enum AVPixelFormat sxpi_pix_fmts_sx2ff(enum sxplayer_pixel_format pix_fmt)
+enum AVPixelFormat nmdi_pix_fmts_nmd2ff(enum nmd_pixel_format pix_fmt)
 {
     for (int i = 0; i < FF_ARRAY_ELEMS(pix_fmts_mapping); i++)
-        if (pix_fmts_mapping[i].sx == pix_fmt)
+        if (pix_fmts_mapping[i].nmd == pix_fmt)
             return pix_fmts_mapping[i].ff;
     return AV_PIX_FMT_NONE;
 }
 
-enum sxplayer_pixel_format sxpi_pix_fmts_ff2sx(enum AVPixelFormat pix_fmt)
+enum nmd_pixel_format nmdi_pix_fmts_ff2nmd(enum AVPixelFormat pix_fmt)
 {
     for (int i = 0; i < FF_ARRAY_ELEMS(pix_fmts_mapping); i++)
         if (pix_fmts_mapping[i].ff == pix_fmt)
-            return pix_fmts_mapping[i].sx;
+            return pix_fmts_mapping[i].nmd;
     return -1;
 }
 
-enum sxplayer_pixel_format sxpi_smp_fmts_ff2sx(enum AVSampleFormat smp_fmt)
+enum nmd_pixel_format nmdi_smp_fmts_ff2nmd(enum AVSampleFormat smp_fmt)
 {
     for (int i = 0; i < FF_ARRAY_ELEMS(smp_fmts_mapping); i++)
         if (smp_fmts_mapping[i].ff == smp_fmt)
-            return smp_fmts_mapping[i].sx;
+            return smp_fmts_mapping[i].nmd;
     return -1;
 }
 
-void sxpi_set_thread_name(const char *name)
+void nmdi_set_thread_name(const char *name)
 {
 #if defined(__APPLE__)
     pthread_setname_np(name);
@@ -86,7 +86,7 @@ void sxpi_set_thread_name(const char *name)
 #endif
 }
 
-void sxpi_update_dimensions(int *width, int *height, int max_pixels)
+void nmdi_update_dimensions(int *width, int *height, int max_pixels)
 {
     if (max_pixels) {
         const int w = *width;

--- a/tests/test_audio.c
+++ b/tests/test_audio.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -14,20 +14,20 @@ int main(int ac, char **av)
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
     int i = 0, ret = 0, r, smp = 0;
-    struct sxplayer_ctx *s = sxplayer_create(filename);
+    struct nmd_ctx *s = nmd_create(filename);
 
     if (!s)
         return -1;
 
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    sxplayer_set_option(s, "avselect", SXPLAYER_SELECT_AUDIO);
-    sxplayer_set_option(s, "audio_texture", 0);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_set_option(s, "avselect", NMD_SELECT_AUDIO);
+    nmd_set_option(s, "audio_texture", 0);
 
     for (r = 0; r < 2; r++) {
         printf("run #%d\n", r+1);
         for (;;) {
-            struct sxplayer_frame *frame = sxplayer_get_next_frame(s);
+            struct nmd_frame *frame = nmd_get_next_frame(s);
 
             if (!frame) {
                 printf("null frame\n");
@@ -37,11 +37,11 @@ int main(int ac, char **av)
                    i++, frame->datap[0], frame->ts, frame->nb_samples, frame->pix_fmt);
             smp += frame->nb_samples;
 
-            sxplayer_release_frame(frame);
+            nmd_release_frame(frame);
         }
     }
 
-    sxplayer_free(&s);
+    nmd_free(&s);
 
     if (smp != 15876000) {
         fprintf(stderr, "decoded %d/15876000 expected samples\n", smp);

--- a/tests/test_audio_seek.c
+++ b/tests/test_audio_seek.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -15,35 +15,35 @@ int main(int ac, char **av)
 
     int ret = 0;
     double last_ts = 0.0;
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    struct sxplayer_frame *frame = NULL;
+    struct nmd_ctx *s = nmd_create(filename);
+    struct nmd_frame *frame = NULL;
 
     if (!s)
         return -1;
 
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "avselect", SXPLAYER_SELECT_AUDIO);
-    sxplayer_set_option(s, "audio_texture", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "avselect", NMD_SELECT_AUDIO);
+    nmd_set_option(s, "audio_texture", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
 
     for (int i = 0; i < 10; i++) {
-        frame = sxplayer_get_next_frame(s);
+        frame = nmd_get_next_frame(s);
 
         if (!frame) {
             fprintf(stderr, "got unexpected null frame\n");
-            sxplayer_free(&s);
+            nmd_free(&s);
             return -1;
         }
         printf("frame #%d / data:%p ts:%f nb_samples:%d sfxsmpfmt:%d\n",
                 i, frame->datap[0], frame->ts, frame->nb_samples, frame->pix_fmt);
         last_ts = frame->ts;
 
-        sxplayer_release_frame(frame);
+        nmd_release_frame(frame);
     }
 
-    sxplayer_seek(s, last_ts);
+    nmd_seek(s, last_ts);
 
-    frame = sxplayer_get_next_frame(s);
+    frame = nmd_get_next_frame(s);
     if (!frame) {
         fprintf(stderr, "expected frame->ts=%f got null frame\n", last_ts);
         ret = -1;
@@ -51,8 +51,8 @@ int main(int ac, char **av)
         fprintf(stderr, "expected frame->ts=%f got frame->ts=%f\n", last_ts, frame->ts);
         ret = -1;
     }
-    sxplayer_release_frame(frame);
-    sxplayer_free(&s);
+    nmd_release_frame(frame);
+    nmd_free(&s);
 
     return ret;
 }

--- a/tests/test_high_refresh_rate.c
+++ b/tests/test_high_refresh_rate.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -13,25 +13,25 @@ int main(int ac, char **av)
     const char *filename = av[1];
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    struct sxplayer_frame *f;
+    struct nmd_ctx *s = nmd_create(filename);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    struct nmd_frame *f;
     const double t = 1/60.;
 
     if (!s)
         return -1;
 
-    f = sxplayer_get_frame(s, 0.);
+    f = nmd_get_frame(s, 0.);
     if (!f)
         return -1;
-    sxplayer_release_frame(f);
-    f = sxplayer_get_frame(s, t);
+    nmd_release_frame(f);
+    f = nmd_get_frame(s, t);
     if (f && f->ts > t) {
         fprintf(stderr, "unexpected frame at %f with ts=%f\n", t, f->ts);
-        sxplayer_release_frame(f);
+        nmd_release_frame(f);
         return -1;
     }
-    sxplayer_free(&s);
+    nmd_free(&s);
     return 0;
 }

--- a/tests/test_image.c
+++ b/tests/test_image.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -13,23 +13,23 @@ int main(int ac, char **av)
     const char *filename = av[1];
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
-    struct sxplayer_info info;
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    struct sxplayer_frame *f;
+    struct nmd_info info;
+    struct nmd_ctx *s = nmd_create(filename);
+    struct nmd_frame *f;
 
     if (!s)
         return -1;
-    sxplayer_set_option(s, "skip", 3.0);
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    f = sxplayer_get_frame(s, 53.0);
+    nmd_set_option(s, "skip", 3.0);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    f = nmd_get_frame(s, 53.0);
     if (!f) {
         fprintf(stderr, "didn't get an image\n");
         return -1;
     }
-    sxplayer_release_frame(f);
+    nmd_release_frame(f);
 
-    if (sxplayer_get_info(s, &info) < 0) {
+    if (nmd_get_info(s, &info) < 0) {
         fprintf(stderr, "can not fetch image info\n");
     }
     if (info.width != 480 || info.height != 640) {
@@ -37,13 +37,13 @@ int main(int ac, char **av)
         return -1;
     }
 
-    f = sxplayer_get_frame(s, 12.3);
+    f = nmd_get_frame(s, 12.3);
     if (f) {
-        sxplayer_release_frame(f);
+        nmd_release_frame(f);
         fprintf(stderr, "we got a new frame even though the source is an image\n");
         return -1;
     }
 
-    sxplayer_free(&s);
+    nmd_free(&s);
     return 0;
 }

--- a/tests/test_image_seek.c
+++ b/tests/test_image_seek.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -13,21 +13,21 @@ int main(int ac, char **av)
     const char *filename = av[1];
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    struct sxplayer_frame *f;
+    struct nmd_ctx *s = nmd_create(filename);
+    struct nmd_frame *f;
 
     if (!s)
         return -1;
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    sxplayer_seek(s, 10.2);
-    f = sxplayer_get_frame(s, 10.5);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_seek(s, 10.2);
+    f = nmd_get_frame(s, 10.5);
     if (!f) {
         fprintf(stderr, "didn't get first image\n");
         return -1;
     }
-    sxplayer_release_frame(f);
+    nmd_release_frame(f);
 
-    sxplayer_free(&s);
+    nmd_free(&s);
     return 0;
 }

--- a/tests/test_microseconds.c
+++ b/tests/test_microseconds.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -14,19 +14,19 @@ int main(int ac, char **av)
     const char *filename = av[1];
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
-    struct sxplayer_ctx *s1 = sxplayer_create(filename);
-    struct sxplayer_ctx *s2 = sxplayer_create(filename);
-    struct sxplayer_frame *f1, *f2;
+    struct nmd_ctx *s1 = nmd_create(filename);
+    struct nmd_ctx *s2 = nmd_create(filename);
+    struct nmd_frame *f1, *f2;
 
     if (!s1 || !s2)
         return -1;
 
-    sxplayer_set_option(s1, "auto_hwaccel", 0);
-    sxplayer_set_option(s1, "use_pkt_duration", use_pkt_duration);
-    sxplayer_set_option(s2, "auto_hwaccel", 0);
-    sxplayer_set_option(s2, "use_pkt_duration", use_pkt_duration);
-    f1 = sxplayer_get_frame(s1, 3.0);
-    f2 = sxplayer_get_frame_ms(s2, 3*1000000);
+    nmd_set_option(s1, "auto_hwaccel", 0);
+    nmd_set_option(s1, "use_pkt_duration", use_pkt_duration);
+    nmd_set_option(s2, "auto_hwaccel", 0);
+    nmd_set_option(s2, "use_pkt_duration", use_pkt_duration);
+    f1 = nmd_get_frame(s1, 3.0);
+    f2 = nmd_get_frame_ms(s2, 3*1000000);
     if (!f1 || !f2)
         return -1;
 
@@ -40,9 +40,9 @@ int main(int ac, char **av)
         return -1;
     }
 
-    sxplayer_release_frame(f1);
-    sxplayer_release_frame(f2);
-    sxplayer_free(&s1);
-    sxplayer_free(&s2);
+    nmd_release_frame(f1);
+    nmd_release_frame(f2);
+    nmd_free(&s1);
+    nmd_free(&s2);
     return 0;
 }

--- a/tests/test_misc_events.c
+++ b/tests/test_misc_events.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -13,41 +13,41 @@ int main(int ac, char **av)
     const char *filename = av[1];
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    struct sxplayer_frame *f;
+    struct nmd_ctx *s = nmd_create(filename);
+    struct nmd_frame *f;
 
     if (!s)
         return -1;
 
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    sxplayer_seek(s, 12.7);
-    sxplayer_seek(s, 21.0);
-    sxplayer_seek(s, 5.3);
-    sxplayer_start(s);
-    sxplayer_start(s);
-    sxplayer_seek(s, 15.3);
-    sxplayer_stop(s);
-    sxplayer_start(s);
-    sxplayer_stop(s);
-    sxplayer_start(s);
-    sxplayer_seek(s, 7.2);
-    sxplayer_start(s);
-    sxplayer_stop(s);
-    sxplayer_seek(s, 82.9);
-    f = sxplayer_get_frame(s, 83.5);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_seek(s, 12.7);
+    nmd_seek(s, 21.0);
+    nmd_seek(s, 5.3);
+    nmd_start(s);
+    nmd_start(s);
+    nmd_seek(s, 15.3);
+    nmd_stop(s);
+    nmd_start(s);
+    nmd_stop(s);
+    nmd_start(s);
+    nmd_seek(s, 7.2);
+    nmd_start(s);
+    nmd_stop(s);
+    nmd_seek(s, 82.9);
+    f = nmd_get_frame(s, 83.5);
     if (!f) {
-        sxplayer_free(&s);
+        nmd_free(&s);
         return -1;
     }
-    sxplayer_release_frame(f);
-    sxplayer_stop(s);
-    f = sxplayer_get_frame(s, 83.5);
+    nmd_release_frame(f);
+    nmd_stop(s);
+    f = nmd_get_frame(s, 83.5);
     if (!f) {
-        sxplayer_free(&s);
+        nmd_free(&s);
         return -1;
     }
-    sxplayer_free(&s);
-    sxplayer_release_frame(f);
+    nmd_free(&s);
+    nmd_release_frame(f);
     return 0;
 }

--- a/tests/test_next_frame.c
+++ b/tests/test_next_frame.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 int main(int ac, char **av)
 {
@@ -14,18 +14,18 @@ int main(int ac, char **av)
     const int use_pkt_duration = ac > 2 ? atoi(av[2]) : 0;
 
     int i = 0, ret = 0, r;
-    struct sxplayer_ctx *s = sxplayer_create(filename);
+    struct nmd_ctx *s = nmd_create(filename);
 
     if (!s)
         return -1;
 
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
 
     for (r = 0; r < 2; r++) {
         printf("run #%d\n", r+1);
         for (;;) {
-            struct sxplayer_frame *frame = sxplayer_get_next_frame(s);
+            struct nmd_frame *frame = nmd_get_next_frame(s);
 
             if (!frame) {
                 printf("null frame\n");
@@ -35,11 +35,11 @@ int main(int ac, char **av)
                    i++, frame->datap[0], frame->ts, frame->width, frame->height,
                    frame->linesizep[0], frame->pix_fmt);
 
-            sxplayer_release_frame(frame);
+            nmd_release_frame(frame);
         }
     }
 
-    sxplayer_free(&s);
+    nmd_free(&s);
 
     if (i != 8192) {
         fprintf(stderr, "decoded %d/8192 expected frames\n", i);

--- a/tests/test_notavail_file.c
+++ b/tests/test_notavail_file.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 static const char *fake_filename = "/i/do/not/exist";
 
@@ -17,16 +17,16 @@ int main(int ac, char **av)
 {
     const int use_pkt_duration = ac > 1 ? atoi(av[1]) : 0;
 
-    struct sxplayer_ctx *s = sxplayer_create(fake_filename);
+    struct nmd_ctx *s = nmd_create(fake_filename);
 
     if (!s)
         return -1;
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
-    sxplayer_set_log_callback(s, (void*)fake_filename, log_callback);
-    sxplayer_release_frame(sxplayer_get_frame(s, -1));
-    sxplayer_release_frame(sxplayer_get_frame(s, 1.0));
-    sxplayer_release_frame(sxplayer_get_frame(s, 3.0));
-    sxplayer_free(&s);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_set_log_callback(s, (void*)fake_filename, log_callback);
+    nmd_release_frame(nmd_get_frame(s, -1));
+    nmd_release_frame(nmd_get_frame(s, 1.0));
+    nmd_release_frame(nmd_get_frame(s, 3.0));
+    nmd_free(&s);
     return 0;
 }

--- a/tests/test_seek_after_eos.c
+++ b/tests/test_seek_after_eos.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sxplayer.h>
+#include <nopemd.h>
 
 #define FLAG_SKIP          (1<<0)
 #define FLAG_END_TIME      (1<<1)
@@ -19,8 +19,8 @@ int main(int ac, char **av)
     const int use_pkt_duration = ac > 3 ? atoi(av[3]) : 0;
 
     int ret = 0, nb_frames = 0;
-    struct sxplayer_ctx *s = sxplayer_create(filename);
-    struct sxplayer_frame *frame = NULL;
+    struct nmd_ctx *s = nmd_create(filename);
+    struct nmd_frame *frame = NULL;
     static const float ts[] = { 0.0, 0.5, 7.65 };
 
     if (!s)
@@ -28,82 +28,82 @@ int main(int ac, char **av)
 
     const double skip     = (flags & FLAG_SKIP)     ? 60.0 : 0.0;
     const double end_time = (flags & FLAG_END_TIME) ? 70.0 : -1.0;
-    const int avselect    = (flags & FLAG_AUDIO)    ? SXPLAYER_SELECT_AUDIO : SXPLAYER_SELECT_VIDEO;
+    const int avselect    = (flags & FLAG_AUDIO)    ? NMD_SELECT_AUDIO : NMD_SELECT_VIDEO;
 
-    sxplayer_set_option(s, "auto_hwaccel", 0);
-    sxplayer_set_option(s, "avselect", avselect);
-    sxplayer_set_option(s, "audio_texture", 0);
-    sxplayer_set_option(s, "skip", skip);
-    sxplayer_set_option(s, "end_time", end_time);
-    sxplayer_set_option(s, "use_pkt_duration", use_pkt_duration);
+    nmd_set_option(s, "auto_hwaccel", 0);
+    nmd_set_option(s, "avselect", avselect);
+    nmd_set_option(s, "audio_texture", 0);
+    nmd_set_option(s, "skip", skip);
+    nmd_set_option(s, "end_time", end_time);
+    nmd_set_option(s, "use_pkt_duration", use_pkt_duration);
 
     printf("run #1 (avselect=%d end_time=%f)\n", avselect, end_time);
     for (;;) {
-        frame = sxplayer_get_next_frame(s);
+        frame = nmd_get_next_frame(s);
         if (!frame) {
             break;
         }
-        sxplayer_release_frame(frame);
+        nmd_release_frame(frame);
         nb_frames++;
     }
 
-    sxplayer_free(&s);
+    nmd_free(&s);
 
     for (int k = 0; k < 4; k++) {
         for (int j = 0; j < sizeof(ts)/sizeof(*ts); j++) {
-            s = sxplayer_create(filename);
+            s = nmd_create(filename);
             if (!s)
                 return -1;
 
-            sxplayer_set_option(s, "auto_hwaccel", 0);
-            sxplayer_set_option(s, "avselect", avselect);
-            sxplayer_set_option(s, "audio_texture", 0);
-            sxplayer_set_option(s, "skip", skip);
-            sxplayer_set_option(s, "end_time", end_time);
+            nmd_set_option(s, "auto_hwaccel", 0);
+            nmd_set_option(s, "avselect", avselect);
+            nmd_set_option(s, "audio_texture", 0);
+            nmd_set_option(s, "skip", skip);
+            nmd_set_option(s, "end_time", end_time);
 
             for (int i = 0; i < nb_frames; i++) {
-                frame = sxplayer_get_next_frame(s);
+                frame = nmd_get_next_frame(s);
                 if (!frame) {
                     fprintf(stderr, "unexpected null frame before EOS\n");
                     ret = -1;
                     goto done;
                 }
-                sxplayer_release_frame(frame);
+                nmd_release_frame(frame);
             }
 
             if (k == 0) {
-                sxplayer_seek(s, ts[j]);
-                frame = sxplayer_get_next_frame(s);
+                nmd_seek(s, ts[j]);
+                frame = nmd_get_next_frame(s);
                 if (!frame) {
-                    fprintf(stderr, "unexpected null frame from sxplayer_get_next_frame() after seeking at %f\n", ts[j]);
+                    fprintf(stderr, "unexpected null frame from nmd_get_next_frame() after seeking at %f\n", ts[j]);
                     ret = -1;
                     goto done;
                 }
             } else if (k == 1) {
-                frame = sxplayer_get_frame(s, ts[j]);
+                frame = nmd_get_frame(s, ts[j]);
                 if (!frame) {
-                    fprintf(stderr, "unexpected null frame from sxplayer_get_frame() after seeking at %f\n", ts[j]);
+                    fprintf(stderr, "unexpected null frame from nmd_get_frame() after seeking at %f\n", ts[j]);
                     ret = -1;
                     goto done;
                 }
             } else if (k == 2) {
-                frame = sxplayer_get_frame(s, 1000.0);
+                frame = nmd_get_frame(s, 1000.0);
                 if (frame) {
                     fprintf(stderr, "unexpected frame at %f with ts=%f\n", 1000.0f, frame->ts);
                     ret = -1;
-                    sxplayer_release_frame(frame);
+                    nmd_release_frame(frame);
                     goto done;
                 }
             } else if (k == 3) {
                 frame = NULL;
             }
-            sxplayer_release_frame(frame);
-            sxplayer_free(&s);
+            nmd_release_frame(frame);
+            nmd_free(&s);
         }
     }
 
 done:
-    sxplayer_free(&s);
+    nmd_free(&s);
 
     return ret;
 }


### PR DESCRIPTION
The sxplayer project is owned by the GoPro company, so a name change is mandatory.

A few subtleties on the rename:
- the project is renamed from `sxplayer` to `nope.media`
- the library is renamed from `libsxplayer` to `libnopemd`
- the public prefix is renamed from `sxplayer_`/`SXPLAYER_` to `nmd_`/`NMD_`
- the shared-internal prefix is renamed from `sxpi_`/`SXPI_` to `nmdi_`/`NMDI_`
- an exception to the first rule is the use of "`NOPE_MEDIA_`" in "`SXPLAYER_`" header protection since this protection is neither a public nor an internally shared symbol
- for the same reason as previous point, `{BUILD,USE}_SXPLAYER_*` have been renamed to `{BUILD,USE}_NOPE_MEDIA_*`
- `sxplayer_options` was not public so it's been renamed to `nmdi_options` instead of `nmd_options`
- a few whitespaces fixes and lines joined happened on lines that changed
- the `sxplayer` tool is renamed to `nope-media`