### PR TITLE
ci/win: use the last FFmpeg build of last month

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -66,8 +66,8 @@ jobs:
 
     runs-on: windows-latest
     env:
-      FFMPEG_SRC: ffmpeg-n6.0-12-ga6dc92968a-win64-gpl-shared-6.0
-      FFMPEG_URL: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-04-03-12-51
+      FFMPEG_SRC: ffmpeg-n6.0-11-g3980415627-win64-lgpl-shared-6.0
+      FFMPEG_URL: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-03-31-12-50
       PKGCONF_SRC: pkgconf-1.9.4
       PKGCONF_URL: https://distfiles.dereferenced.org/pkgconf
 


### PR DESCRIPTION
The daily builds are only kept for 14 days while the last build of each month is kept for two years.

Also uses the LGPL build instead of the GPL one as it is lighter.

Fixes the MSVC builds.