### PR TITLE
mod_filtering: workaround a RDFT regression

### DIFF
--- a/src/mod_filtering.c
+++ b/src/mod_filtering.c
@@ -379,8 +379,8 @@ int nmdi_filtering_init(void *log_ctx,
             return AVERROR(ENOMEM);
         }
 
-        ctx->rdft_data[0] = av_calloc(AUDIO_NBSAMPLES, sizeof(*ctx->rdft_data[0]));
-        ctx->rdft_data[1] = av_calloc(AUDIO_NBSAMPLES, sizeof(*ctx->rdft_data[1]));
+        ctx->rdft_data[0] = av_calloc(AUDIO_NBSAMPLES + 2, sizeof(*ctx->rdft_data[0]));
+        ctx->rdft_data[1] = av_calloc(AUDIO_NBSAMPLES + 2, sizeof(*ctx->rdft_data[1]));
         if (!ctx->rdft_data[0] || !ctx->rdft_data[1])
             return AVERROR(ENOMEM);
     }


### PR DESCRIPTION
Workarounds a RDFT regression introduced by its migration to av_tx, see
https://ffmpeg.org/pipermail/ffmpeg-devel/2024-February/321168.html.

Fixes invalid memory writes leading to a crash on macOS.