### PR TITLE
build: require FFmpeg >= 6.1

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -66,8 +66,8 @@ jobs:
 
     runs-on: windows-latest
     env:
-      FFMPEG_SRC: ffmpeg-n6.0-11-g3980415627-win64-lgpl-shared-6.0
-      FFMPEG_URL: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-03-31-12-50
+      FFMPEG_SRC: ffmpeg-n7.0-21-gfb8f0ea7b3-win64-gpl-shared-7.0
+      FFMPEG_URL: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-04-30-12-51
       PKGCONF_SRC: pkgconf-1.9.4
       PKGCONF_URL: https://distfiles.dereferenced.org/pkgconf
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Support for FFmpeg < 6.1
 
 ## [12.0.1] - 2024-06-03
 ### Fixed

--- a/meson.build
+++ b/meson.build
@@ -47,10 +47,10 @@ endif
 lib_deps = [
   cc.find_library('m', required: false),
   dependency('threads'),
-  dependency('libavformat', version: '>= 58.12.100'),
-  dependency('libavfilter', version: '>= 7.16.100'),
-  dependency('libavcodec', version: '>= 58.18.100'),
-  dependency('libavutil', version: '>= 56.14.100'),
+  dependency('libavformat', version: '>= 60.16.100'),
+  dependency('libavfilter', version: '>= 9.12.100'),
+  dependency('libavcodec', version: '>= 60.31.102'),
+  dependency('libavutil', version: '>= 58.29.100'),
 ]
 
 vaapi_dep = dependency('libva', version: '>= 1.1.0', required: get_option('vaapi'))

--- a/src/api.c
+++ b/src/api.c
@@ -879,11 +879,7 @@ int nmd_get_frame_ms(struct nmd_ctx *s, int64_t t64, struct nmd_frame **framep)
          * possible. */
         const int64_t rescaled_vt = stream_time(s, vt);
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 30, 100)
         const int64_t next_duration = next->duration;
-#else
-        const int64_t next_duration = next->pkt_duration;
-#endif
 
         if (s->opts.use_pkt_duration && next_duration > 0 && rescaled_vt >= next->pts) {
             const int64_t next_guessed_pts = next->pts + next_duration;

--- a/src/decoder_vt.c
+++ b/src/decoder_vt.c
@@ -321,14 +321,12 @@ static int pix_fmt_ff2vt(enum AVPixelFormat ff_pix_fmt, OSType *cv_pix_fmt, int 
         *cv_pix_fmt = color_range == AVCOL_RANGE_JPEG ? kCVPixelFormatType_420YpCbCr10BiPlanarFullRange
                                                       : kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange;
         break;
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 9, 100)
     case AV_PIX_FMT_P210:
         *cv_pix_fmt = kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange;
         break;
     case AV_PIX_FMT_P410:
         *cv_pix_fmt = kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange;
         break;
-#endif
     case AV_PIX_FMT_BGRA:
         *cv_pix_fmt = kCVPixelFormatType_32BGRA;
         break;
@@ -403,10 +401,8 @@ static enum AVPixelFormat select_pix_fmt(const enum AVPixelFormat *pix_fmts,
         AV_PIX_FMT_NV16,
         AV_PIX_FMT_NV20,
         AV_PIX_FMT_P010,
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 9, 100)
         AV_PIX_FMT_P210,
         AV_PIX_FMT_P410,
-#endif
         AV_PIX_FMT_BGRA,
     };
     enum AVPixelFormat best = AV_PIX_FMT_NONE;

--- a/src/mod_decoding.c
+++ b/src/mod_decoding.c
@@ -30,11 +30,7 @@
 
 static void nmi_channel_layout_describe(const AVCodecParameters *par, char *buf, size_t buf_size)
 {
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(57, 24, 100)
-    av_get_channel_layout_string(buf, buf_size, 0, par->channel_layout);
-#else
     av_channel_layout_describe(&par->ch_layout, buf, buf_size);
-#endif
 }
 
 extern const struct decoder nmdi_decoder_ffmpeg_sw;

--- a/src/mod_decoding.c
+++ b/src/mod_decoding.c
@@ -28,11 +28,6 @@
 #include "msg.h"
 #include "log.h"
 
-static void nmi_channel_layout_describe(const AVCodecParameters *par, char *buf, size_t buf_size)
-{
-    av_channel_layout_describe(&par->ch_layout, buf, buf_size);
-}
-
 extern const struct decoder nmdi_decoder_ffmpeg_sw;
 extern const struct decoder nmdi_decoder_ffmpeg_hw;
 static const struct decoder *decoder_def_software = &nmdi_decoder_ffmpeg_sw;
@@ -111,7 +106,7 @@ int nmdi_decoding_init(void *log_ctx,
 #define DUMP_INFO(par, name) do {                                       \
     if ((par)->codec_type == AVMEDIA_TYPE_AUDIO) {                      \
         char chl[1024];                                                 \
-        nmi_channel_layout_describe((par), chl, sizeof(chl));           \
+        av_channel_layout_describe(&(par)->ch_layout, chl, sizeof(chl)); \
         TRACE(ctx, name " stream: %s %s @ %dHz tb=%d/%d",               \
               chl, av_get_sample_fmt_name((par)->format),               \
               (par)->sample_rate,                                       \

--- a/src/mod_demuxing.c
+++ b/src/mod_demuxing.c
@@ -71,13 +71,9 @@ double nmdi_demuxing_probe_rotation(const struct demuxing_ctx *ctx)
 {
     AVStream *st = (AVStream *)ctx->stream; // XXX: Fix FFmpeg.
     AVDictionaryEntry *rotate_tag = av_dict_get(st->metadata, "rotate", NULL, 0);
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(60, 29, 100)
     const AVCodecParameters *par = st->codecpar;
     const AVPacketSideData *side_data = av_packet_side_data_get(par->coded_side_data, par->nb_coded_side_data, AV_PKT_DATA_DISPLAYMATRIX);
     const uint8_t *displaymatrix = side_data ? side_data->data : NULL;
-#else
-    const uint8_t *displaymatrix = av_stream_get_side_data(st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
-#endif
     double theta = 0;
 
     if (rotate_tag && *rotate_tag->value && strcmp(rotate_tag->value, "0")) {

--- a/src/mod_filtering.c
+++ b/src/mod_filtering.c
@@ -655,9 +655,7 @@ void nmdi_filtering_free(struct filtering_ctx **fp)
         av_freep(&ctx->window_func_lut);
         av_freep(&ctx->rdft_data[0]);
         av_freep(&ctx->rdft_data[1]);
-        if (ctx->avtx) {
-            av_tx_uninit(&ctx->avtx);
-        }
+        av_tx_uninit(&ctx->avtx);
     }
     avfilter_graph_free(&ctx->filter_graph);
     avcodec_parameters_free(&ctx->codecpar);

--- a/src/mod_filtering.c
+++ b/src/mod_filtering.c
@@ -139,13 +139,9 @@ static void audio_frame_to_sound_texture(struct filtering_ctx *ctx, AVFrame *dst
         /* Run transform.
          *
          * After avtx_func(), the bins are an array of successive real and
-         * imaginary floats of size NB_SAMPLES/2 + 1. To mimic the
-         * av_rdft_calc() behavior, we simply copy the real part of the higher
-         * frequency into the imaginary part of the first bin. It also requires
-         * the bins allocation to be at least of size (nb_samples + 2) * sizeof(float).
+         * imaginary floats of size NB_SAMPLES/2 + 1.
          */
         ctx->avtx_func(ctx->avtx, bins, bins, sizeof(float));
-        bins[1] = bins[nb_samples];
 
         /* Get magnitude of frequency bins and copy result into texture
          *
@@ -153,8 +149,7 @@ static void audio_frame_to_sound_texture(struct filtering_ctx *ctx, AVFrame *dst
          * the last complex (highest frequency one).
          */
 #define MAGNITUDE(re, im) (hypotf(re, im) * scale)
-        fft_dst[0] = MAGNITUDE(bins[0], 0); // lowest frequency
-        for (int i = 1; i < width; i++)
+        for (int i = 0; i < width; i++)
             fft_dst[i] = MAGNITUDE(bins[2*i], bins[2*i + 1]);
     }
 

--- a/src/mod_filtering.c
+++ b/src/mod_filtering.c
@@ -80,7 +80,7 @@ struct filtering_ctx {
     float *window_func_lut;                 // audio window function lookup table
     AVTXContext *avtx;
     av_tx_fn avtx_func;
-    FFTSample *rdft_data[AUDIO_NBCHANNELS]; // real discrete fourier transform data for each channel
+    float *rdft_data[AUDIO_NBCHANNELS];     // real discrete fourier transform data for each channel
 };
 
 struct filtering_ctx *nmdi_filtering_alloc(void)


### PR DESCRIPTION
The latest Ubuntu LTS release (24.04) ships with FFmpeg 6.1, so we can depend on it for the time being.